### PR TITLE
add nix package manager support

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,12 @@ cd better-curl-saul
 ```bash
 saul set url https://raw.githubusercontent.com/DeprecatedLuar/better-curl-saul/main/install.sh && saul call --raw | bash #(maybe works, who knows)
 ```
+**Using Nix and Flakes**
+```bash
+nix profile install github:DeprecatedLuar/better-curl-saul?dir=nix-saul
+```
+The `saul` command will be available in your PATH
+
 >[!NOTE]
 > Quick install auto-detects your system and downloads binaries or builds from source as fallback. 
 > Windows users: I don't know powershell I expect you to have bash 👍

--- a/nix-saul/README.md
+++ b/nix-saul/README.md
@@ -1,0 +1,51 @@
+# Using Nix BTW
+
+**TLDR**: install with `nix profile install github:DeprecatedLuar/better-curl-saul?dir=nix-saul`, `saul` command will be available in your shell
+
+---
+
+## Using Nix Flakes for development
+If you have flakes enabled, you can use these commands in the root of the repo:
+
+- **Build**
+  ```bash
+  nix build ./nix-saul
+  ```
+  The built binary will be available in `./result/bin/saul`.
+
+- **Run**
+  ```bash
+  nix run ./nix-saul
+  ```
+  This runs the `saul` binary directly.
+
+- **Install to your user profile**
+  ```bash
+  nix profile install ./nix-saul
+  ```
+  The binary will be available in your `$PATH`.
+
+- **Enter Dev Shell**
+  ```bash
+  nix develop ./nix-saul
+  ```
+  This starts a shell with all Go dependencies available.
+
+---
+
+## Run Directly From GitHub (No Clone Needed)
+
+You can build, run and install the binary directly from GitHub using Nix flakes:
+
+- **Build**
+  ```bash
+  nix build github:DeprecatedLuar/better-curl-saul?dir=nix-saul
+  ```
+- **Run**
+  ```bash
+  nix run github:DeprecatedLuar/better-curl-saul?dir=nix-saul
+  ```
+- **Install to your user profile**
+  ```bash
+  nix profile install github:DeprecatedLuar/better-curl-saul?dir=nix-saul
+  ```

--- a/nix-saul/default.nix
+++ b/nix-saul/default.nix
@@ -1,0 +1,29 @@
+{ pkgs ? import <nixpkgs> {} }:
+
+pkgs.buildGoModule {
+  pname = "better-curl-saul";
+  version = "v0.3.0";
+
+  src = pkgs.fetchFromGitHub {
+    owner = "DeprecatedLuar";
+    repo = "better-curl-saul";
+    rev = "main";
+    sha256 = "sha256-KIJndQxICxDB7w6snQeserCVTVC8u/ueFfwo5L8souQ=";
+  };
+
+  vendorHash = "sha256-h/W5e64XQmfDgW6JPgxOJ1Jw8B18SsaX31nDvPTAQHI=";
+
+  subPackages = [ "cmd" ];
+
+  postInstall = ''
+    mv $out/bin/cmd $out/bin/saul
+  '';
+
+  meta = with pkgs.lib; {
+    description = "Did you know you have rights? The FOSS says you do... Better Curl Saul is my homemade CLI 'http client' to make api reusability simple";
+    license = licenses.mit;
+    maintainers = [ "DeprecatedLuar" ];
+    homepage = "https://github.com/DeprecatedLuar/better-curl-saul";
+    platforms = platforms.linux ++ platforms.darwin ++ platforms.windows;
+  };
+}

--- a/nix-saul/flake.lock
+++ b/nix-saul/flake.lock
@@ -1,0 +1,60 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1759523778,
+        "narHash": "sha256-TqZuRU3mf9HJ42kb+Hu6ynWcYbG41C4SiBMujEwV5B0=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "42544f3a2e89a98c4b0b58b340aa85d2ae1f3202",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/nix-saul/flake.nix
+++ b/nix-saul/flake.nix
@@ -1,0 +1,19 @@
+{
+  description = "Better Curl Saul - FOSS HTTP client";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs";
+  inputs.flake-utils.url = "github:numtide/flake-utils";
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+      in {
+        packages.default = pkgs.callPackage ./default.nix {};
+        devShell = pkgs.callPackage ./shell.nix {};
+        apps.default = {
+          type = "app";
+          program = "${self.packages.${system}.default}/bin/saul";
+        };
+      }
+    );
+}

--- a/nix-saul/shell.nix
+++ b/nix-saul/shell.nix
@@ -1,0 +1,7 @@
+{ pkgs ? import <nixpkgs> {} }:
+
+pkgs.mkShell {
+  buildInputs = with pkgs; [
+    go
+  ];
+}


### PR DESCRIPTION
This adds Nix Packaging for better-curl-saul. Running, building, installing the binary, as well as and creating development shells is supported.

This is something I set up for my own development workflow, but I wanted to share it so others can benefit from it!

If anyone is using Nix, feedback and testing would be greatly appreciated! I will have to test the commands that use the github URL for the main repo once the PR is merged, as it depends on the code being available in the main branch.
