### PR TITLE
fix: use relative path in nix package src

### DIFF
--- a/nix-saul/default.nix
+++ b/nix-saul/default.nix
@@ -4,12 +4,7 @@ pkgs.buildGoModule {
   pname = "better-curl-saul";
   version = "v0.3.0";
 
-  src = pkgs.fetchFromGitHub {
-    owner = "DeprecatedLuar";
-    repo = "better-curl-saul";
-    rev = "main";
-    sha256 = "sha256-KIJndQxICxDB7w6snQeserCVTVC8u/ueFfwo5L8souQ=";
-  };
+  src = ../.;
 
   vendorHash = "sha256-h/W5e64XQmfDgW6JPgxOJ1Jw8B18SsaX31nDvPTAQHI=";
 

--- a/nix-saul/default.nix
+++ b/nix-saul/default.nix
@@ -4,7 +4,7 @@ pkgs.buildGoModule {
   pname = "better-curl-saul";
   version = "v0.3.0";
 
-  src = ../.;
+  src = pkgs.lib.cleanSource ../.;
 
   vendorHash = "sha256-h/W5e64XQmfDgW6JPgxOJ1Jw8B18SsaX31nDvPTAQHI=";
 


### PR DESCRIPTION
To simplify nix setup for saul, I added a simple change that will allow us to always fetch the code from the selected branch when building the nix package. This way, we will not require a github commit hash update on every new version. We will only need to update the default.nix file if the dependencies in go.mod change.

References #14 (needs to be tested after merging)